### PR TITLE
Improve portal design with card-based layout

### DIFF
--- a/hub/templates/hub/dashboard.html
+++ b/hub/templates/hub/dashboard.html
@@ -2,11 +2,14 @@
 {% block title %}Hub{% endblock %}
 {% block content %}
 <h1 class="text-3xl mb-4">Departments</h1>
-<ul>
+<div class="grid md:grid-cols-3 gap-6">
 {% for dept in departments %}
-  <li class="mb-2 p-4 bg-white rounded shadow">{{ dept.name }}</li>
+  <div class="p-4 bg-white rounded shadow hover:shadow-lg transition">
+    <h2 class="text-xl font-semibold flex items-center">{{ dept.name }} <span class="ml-2 text-blue-600">&gt;</span></h2>
+    <p class="text-sm text-gray-500">Created {{ dept.created_at|date:'M d, Y' }}</p>
+  </div>
 {% empty %}
-  <li>No departments yet.</li>
+  <p>No departments yet.</p>
 {% endfor %}
-</ul>
+</div>
 {% endblock %}

--- a/hub/templates/hub/home.html
+++ b/hub/templates/hub/home.html
@@ -1,0 +1,34 @@
+{% extends 'base.html' %}
+{% block title %}Home{% endblock %}
+{% block content %}
+<section class="grid md:grid-cols-3 md:grid-rows-2 gap-6">
+    {% with main=posts.0 %}
+    <article class="md:col-span-2 md:row-span-2 bg-white rounded-lg shadow hover:shadow-lg transition">
+        <img src="{{ main.image }}" alt="" class="w-full h-56 object-cover rounded-t-lg">
+        <div class="p-6">
+            <p class="text-sm text-gray-500">{{ main.category }} · {{ main.date }} · {{ main.read_time }} min read</p>
+            <h2 class="text-2xl font-bold mt-2 flex items-center">{{ main.title }} <span class="ml-2 text-blue-600">&gt;</span></h2>
+            <p class="mt-2 text-gray-700">{{ main.summary }}</p>
+        </div>
+    </article>
+    {% endwith %}
+    {% with second=posts.1 %}
+    <article class="bg-white rounded-lg shadow hover:shadow-lg transition flex flex-col">
+        <img src="{{ second.image }}" alt="" class="w-full h-40 object-cover rounded-t-lg">
+        <div class="p-4 flex flex-col flex-1">
+            <p class="text-sm text-gray-500">{{ second.category }} · {{ second.date }} · {{ second.read_time }} min read</p>
+            <h3 class="text-xl font-bold mt-2 flex-1 flex items-center">{{ second.title }} <span class="ml-2 text-blue-600">&gt;</span></h3>
+        </div>
+    </article>
+    {% endwith %}
+    {% with third=posts.2 %}
+    <article class="bg-white rounded-lg shadow hover:shadow-lg transition flex flex-col">
+        <img src="{{ third.image }}" alt="" class="w-full h-40 object-cover rounded-t-lg">
+        <div class="p-4 flex flex-col flex-1">
+            <p class="text-sm text-gray-500">{{ third.category }} · {{ third.date }} · {{ third.read_time }} min read</p>
+            <h3 class="text-xl font-bold mt-2 flex-1 flex items-center">{{ third.title }} <span class="ml-2 text-blue-600">&gt;</span></h3>
+        </div>
+    </article>
+    {% endwith %}
+</section>
+{% endblock %}

--- a/hub/urls.py
+++ b/hub/urls.py
@@ -1,9 +1,10 @@
 from django.urls import path
-from .views import DepartmentListView, DepartmentCreateView
+from .views import DepartmentListView, DepartmentCreateView, PortalHomeView
 
 app_name = "hub"
 
 urlpatterns = [
     path("", DepartmentListView.as_view(), name="dashboard"),
+    path("home/", PortalHomeView.as_view(), name="home"),
     path("departments/new/", DepartmentCreateView.as_view(), name="department-create"),
 ]

--- a/hub/views.py
+++ b/hub/views.py
@@ -1,7 +1,7 @@
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.views import LoginView
 from django.urls import reverse_lazy
-from django.views.generic import ListView, CreateView
+from django.views.generic import ListView, CreateView, TemplateView
 
 from .models import Department
 from .forms import DepartmentForm
@@ -26,3 +26,35 @@ class DepartmentCreateView(LoginRequiredMixin, CreateView):
     def form_valid(self, form):
         form.instance.created_by = self.request.user
         return super().form_valid(form)
+
+
+class PortalHomeView(TemplateView):
+    template_name = "hub/home.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["posts"] = [
+            {
+                "title": "The future of AI apps and agents starts here",
+                "summary": "Explore how AI agents are reshaping the tech landscape.",
+                "category": "Announcements",
+                "date": "Aug 7, 2025",
+                "read_time": 6,
+                "image": "https://via.placeholder.com/800x400",
+            },
+            {
+                "title": "Building secure multi-agent systems",
+                "category": "Security",
+                "date": "Jul 12, 2025",
+                "read_time": 4,
+                "image": "https://via.placeholder.com/400x200",
+            },
+            {
+                "title": "Optimizing cloud costs with AI",
+                "category": "Best Practices",
+                "date": "Jun 30, 2025",
+                "read_time": 5,
+                "image": "https://via.placeholder.com/400x200",
+            },
+        ]
+        return context

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,13 +7,27 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css">
 </head>
 <body class="bg-gray-50 text-gray-900">
-<nav class="p-4 bg-gradient-to-r from-blue-600 to-purple-600 text-white">
-    <span class="font-bold">AI Hub</span>
-    {% if user.is_authenticated %}
-    <a href="/logout/" class="float-right">Logout</a>
-    {% endif %}
+<nav class="bg-gradient-to-r from-blue-600 to-purple-600 text-white">
+    <div class="max-w-7xl mx-auto p-4 flex flex-wrap items-center justify-between">
+        <a href="{% url 'hub:home' %}" class="font-bold text-lg">AI Hub</a>
+        <div class="flex flex-wrap items-center space-x-2">
+            <select class="bg-white text-gray-900 rounded p-1">
+                <option>Content Type</option>
+            </select>
+            <select class="bg-white text-gray-900 rounded p-1">
+                <option>Product</option>
+            </select>
+            <select class="bg-white text-gray-900 rounded p-1">
+                <option>Audience</option>
+            </select>
+            <input type="text" placeholder="Search" class="p-1 rounded text-gray-900" />
+            {% if user.is_authenticated %}
+            <a href="/logout/" class="ml-2">Logout</a>
+            {% endif %}
+        </div>
+    </div>
 </nav>
-<main class="p-6">
+<main class="max-w-7xl mx-auto p-6">
     {% block content %}{% endblock %}
 </main>
 </body>


### PR DESCRIPTION
## Summary
- Style header with brand link, filter dropdowns, and search bar
- Add responsive home page template with featured article and secondary cards
- Convert department dashboard to card grid and expose new home route

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a04e7466548327aed4bbb3a238c7bf