### PR TITLE
Add Microsoft and Google login options

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,28 @@ $ python manage.py runserver
 2. Create departments from `/departments/new/`.
 3. Extend AI settings and OAuth providers via `portal/settings.py` and future configuration modules.
 
+### Microsoft and Google Login
+
+To enable single sign-on via MSAL:
+
+1. **Register Applications**
+   - For Microsoft, register an app in Azure AD and note the client ID and secret.
+   - For Google, create OAuth credentials in the Google Cloud console.
+2. **Configure Environment**
+   - Set the following environment variables before running the server:
+     ```bash
+     export MICROSOFT_CLIENT_ID=<app-id>
+     export MICROSOFT_CLIENT_SECRET=<secret>
+     export MICROSOFT_AUTHORITY=https://login.microsoftonline.com/common
+     export MICROSOFT_REDIRECT_URI=http://localhost:8000/auth/microsoft/callback/
+
+     export GOOGLE_CLIENT_ID=<google-client-id>
+     export GOOGLE_CLIENT_SECRET=<google-client-secret>
+     export GOOGLE_REDIRECT_URI=http://localhost:8000/auth/google/callback/
+     ```
+3. **Use the Routes**
+   - Navigate to `/login/` and choose **Sign in with Microsoft** or **Sign in with Google**.
+
 ## Documentation
 
 To build HTML documentation from docstrings:

--- a/hub/templates/hub/login.html
+++ b/hub/templates/hub/login.html
@@ -1,11 +1,23 @@
 {% extends 'base.html' %}
 {% block title %}Login{% endblock %}
 {% block content %}
-<div class="max-w-md mx-auto bg-white p-6 rounded shadow">
-  <h1 class="text-2xl mb-4">Login</h1>
-  <form method="post">{% csrf_token %}
-    {{ form.as_p }}
-    <button class="mt-4 bg-blue-600 text-white py-2 px-4 rounded" type="submit">Sign in</button>
-  </form>
+<div class="min-h-screen flex items-center justify-center">
+  <div class="w-full max-w-md bg-white p-8 rounded-lg shadow-lg">
+    <h1 class="text-3xl font-bold mb-6 text-center">Sign in to AI Hub</h1>
+    <form method="post" class="space-y-4">{% csrf_token %}
+      {{ form.as_p }}
+      <button class="w-full bg-blue-600 hover:bg-blue-700 text-white py-2 rounded" type="submit">Sign in with Email</button>
+    </form>
+    <div class="mt-6 space-y-2">
+      <a href="{% url 'microsoft-login' %}" class="w-full flex items-center justify-center bg-blue-700 hover:bg-blue-800 text-white py-2 rounded">
+        <img src="https://upload.wikimedia.org/wikipedia/commons/4/44/Microsoft_logo.svg" alt="Microsoft" class="h-5 w-5 mr-2"/>
+        Sign in with Microsoft
+      </a>
+      <a href="{% url 'google-login' %}" class="w-full flex items-center justify-center bg-red-600 hover:bg-red-700 text-white py-2 rounded">
+        <img src="https://upload.wikimedia.org/wikipedia/commons/4/4d/Google_%22G%22_Logo.svg" alt="Google" class="h-5 w-5 mr-2"/>
+        Sign in with Google
+      </a>
+    </div>
+  </div>
 </div>
 {% endblock %}

--- a/portal/settings.py
+++ b/portal/settings.py
@@ -10,6 +10,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/5.2/ref/settings/
 """
 
+import os
 from pathlib import Path
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -130,3 +131,20 @@ LOGIN_URL = "/login/"
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+
+# OAuth configuration
+MICROSOFT_CLIENT_ID = os.environ.get("MICROSOFT_CLIENT_ID", "")
+MICROSOFT_CLIENT_SECRET = os.environ.get("MICROSOFT_CLIENT_SECRET", "")
+MICROSOFT_AUTHORITY = os.environ.get(
+    "MICROSOFT_AUTHORITY", "https://login.microsoftonline.com/common"
+)
+MICROSOFT_REDIRECT_URI = os.environ.get(
+    "MICROSOFT_REDIRECT_URI", "http://localhost:8000/auth/microsoft/callback/"
+)
+
+GOOGLE_CLIENT_ID = os.environ.get("GOOGLE_CLIENT_ID", "")
+GOOGLE_CLIENT_SECRET = os.environ.get("GOOGLE_CLIENT_SECRET", "")
+GOOGLE_REDIRECT_URI = os.environ.get(
+    "GOOGLE_REDIRECT_URI", "http://localhost:8000/auth/google/callback/"
+)

--- a/portal/urls.py
+++ b/portal/urls.py
@@ -17,12 +17,26 @@ Including another URLconf
 
 from django.contrib import admin
 from django.urls import path, include
-from hub.views import PortalLoginView
+from hub.views import (
+    PortalLoginView,
+    google_callback,
+    google_login,
+    microsoft_callback,
+    microsoft_login,
+)
 from django.contrib.auth.views import LogoutView
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("login/", PortalLoginView.as_view(), name="login"),
     path("logout/", LogoutView.as_view(), name="logout"),
+    path("auth/microsoft/", microsoft_login, name="microsoft-login"),
+    path(
+        "auth/microsoft/callback/",
+        microsoft_callback,
+        name="microsoft-callback",
+    ),
+    path("auth/google/", google_login, name="google-login"),
+    path("auth/google/callback/", google_callback, name="google-callback"),
     path("", include("hub.urls", namespace="hub")),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ Django>=5.0,<6.0
 authlib
 msal
 google-auth
+google-auth-oauthlib
 openai
 langchain
 sphinx


### PR DESCRIPTION
## Summary
- style login page and add buttons for Microsoft and Google sign-in
- expose MSAL-based login routes for both providers
- document OAuth configuration in README and settings

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0509ab6b0832780780e35c9b44e21