### PR TITLE
Hide navigation on login page

### DIFF
--- a/hub/templates/hub/login.html
+++ b/hub/templates/hub/login.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% block title %}Login{% endblock %}
+{% block nav %}{% endblock %}
 {% block content %}
 <div class="min-h-screen flex items-center justify-center">
   <div class="w-full max-w-md bg-white p-8 rounded-lg shadow-lg">

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css">
 </head>
 <body class="bg-gray-50 text-gray-900">
+{% block nav %}
 <nav class="bg-gradient-to-r from-blue-600 to-purple-600 text-white">
     <div class="max-w-7xl mx-auto p-4 flex flex-wrap items-center justify-between">
         <a href="{% url 'hub:home' %}" class="font-bold text-lg">AI Hub</a>
@@ -27,6 +28,7 @@
         </div>
     </div>
 </nav>
+{% endblock %}
 <main class="max-w-7xl mx-auto p-6">
     {% block content %}{% endblock %}
 </main>


### PR DESCRIPTION
## Summary
- allow base template's navigation to be overridden by a new `nav` block
- suppress navigation on the login page for a cleaner appearance

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0532b9a008327a8b7485f00fe8cb4