### PR TITLE
Add themeable CSS architecture

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,0 +1,58 @@
+/* Root variables and themes */
+:root {
+  --color-bg: #ffffff;
+  --color-text: #1a1a1a;
+  --color-primary: #2563eb; /* blue-600 */
+  --color-secondary: #9333ea; /* purple-600 */
+  --spacing-400: 2rem;
+  --spacing-xl: 4rem;
+  font-size: 16px;
+}
+
+/* Dark theme overrides */
+.theme-dark {
+  --color-bg: #1a1a1a;
+  --color-text: #f3f4f6;
+  --color-primary: #3b82f6;
+  --color-secondary: #a855f7;
+}
+
+/* Global styles */
+body {
+  background-color: var(--color-bg);
+  color: var(--color-text);
+  font-family: 'Segoe UI', sans-serif;
+  margin: 0;
+  padding: 0;
+}
+
+/* Component styles */
+.msx-card {
+  background: var(--color-bg);
+  border: 1px solid var(--color-primary);
+  border-radius: 0.5rem;
+  padding: var(--spacing-400);
+  box-shadow: 0 1px 2px rgb(0 0 0 / 0.05);
+}
+
+.msx-content-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.c-uhff {
+  background: var(--color-primary);
+  color: #fff;
+  padding: var(--spacing-400);
+}
+
+.c-uhff a {
+  color: #fff;
+  text-decoration: none;
+}
+
+/* Theme selector layout */
+#theme-selector {
+  cursor: pointer;
+}

--- a/static/js/theme.js
+++ b/static/js/theme.js
@@ -1,0 +1,14 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const btn = document.getElementById('theme-selector');
+  if (!btn) return;
+  btn.addEventListener('click', () => {
+    const body = document.body;
+    if (body.classList.contains('theme-dark')) {
+      body.classList.remove('theme-dark');
+      body.classList.add('theme-light');
+    } else {
+      body.classList.remove('theme-light');
+      body.classList.add('theme-dark');
+    }
+  });
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,3 +1,4 @@
+{% load static %}
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -5,8 +6,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}Portal{% endblock %}</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css">
+    <link rel="stylesheet" href="{% static 'css/style.css' %}">
 </head>
-<body class="bg-gray-50 text-gray-900">
+<body class="theme-light">
 {% block nav %}
 <nav class="bg-gradient-to-r from-blue-600 to-purple-600 text-white">
     <div class="max-w-7xl mx-auto p-4 flex flex-wrap items-center justify-between">
@@ -22,6 +24,7 @@
                 <option>Audience</option>
             </select>
             <input type="text" placeholder="Search" class="p-1 rounded text-gray-900" />
+            <button id="theme-selector" class="ml-2 bg-white text-gray-900 rounded p-1">Toggle Theme</button>
             {% if user.is_authenticated %}
             <a href="/logout/" class="ml-2">Logout</a>
             {% endif %}
@@ -33,4 +36,5 @@
     {% block content %}{% endblock %}
 </main>
 </body>
+<script src="{% static 'js/theme.js' %}"></script>
 </html>


### PR DESCRIPTION
## Summary
- add component-driven CSS file with light and dark theme variables
- add simple theme toggle script and link into base template

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a054e3556483278665a3e72cf491c5